### PR TITLE
Using JAX-RS 1.1 annotations instead of Spring Cloud or Feign annotations

### DIFF
--- a/hystrix-feign/build.gradle
+++ b/hystrix-feign/build.gradle
@@ -30,7 +30,8 @@ dependencies {
     compile('org.springframework.cloud:spring-cloud-starter-hystrix:1.0.0.RELEASE')
     compile('org.springframework.cloud:spring-cloud-starter-hystrix-dashboard:1.0.0.RELEASE')
     compile('org.springframework.cloud:spring-cloud-starter-feign:1.0.4.RELEASE')
-    compile 'com.netflix.feign:feign-hystrix:8.14.4'
+    compile('com.netflix.feign:feign-hystrix:8.14.4')
+    compile('com.netflix.feign:feign-jaxrs:8.14.4')
 
     compile('net.rakugakibox.springbootext:spring-boot-ext-logback-access:1.0')
     testCompile('org.springframework.boot:spring-boot-starter-test')

--- a/hystrix-feign/src/main/java/com/scmspain/howtospring/hystrixfeign/FeignConfiguration.java
+++ b/hystrix-feign/src/main/java/com/scmspain/howtospring/hystrixfeign/FeignConfiguration.java
@@ -1,7 +1,9 @@
 package com.scmspain.howtospring.hystrixfeign;
 
+import feign.Contract;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
+import feign.jaxrs.JAXRSContract;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -13,6 +15,11 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Configuration
 public class FeignConfiguration {
     private static final org.slf4j.Logger logger = LoggerFactory.getLogger(FeignConfiguration.class);
+
+    @Bean
+    public Contract feignContract() {
+        return new JAXRSContract();
+    }
 
     @Bean
     @ConditionalOnClass(RequestInterceptor.class)

--- a/hystrix-feign/src/main/java/com/scmspain/howtospring/hystrixfeign/UserServiceRestClient.java
+++ b/hystrix-feign/src/main/java/com/scmspain/howtospring/hystrixfeign/UserServiceRestClient.java
@@ -1,32 +1,44 @@
 package com.scmspain.howtospring.hystrixfeign;
 
 import org.springframework.cloud.netflix.feign.FeignClient;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import rx.Observable;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import java.util.List;
 
 @FeignClient(name = "discovery-eureka", configuration = FeignConfiguration.class)
 public interface UserServiceRestClient {
 
-    @RequestMapping(value = "/users", method = RequestMethod.GET)
+    @GET
+    @Path("/users")
     Observable<List<User>> getUsers();
 
-    @RequestMapping(value = "/users/{userId}", method = RequestMethod.GET)
-    Observable<User> getUser(@PathVariable("userId") String userId);
+    @GET
+    @Path("/users/{userId}")
+    Observable<User> getUser(@PathParam("userId") String userId);
 
-    @RequestMapping(value = "/users", method = RequestMethod.POST, consumes = "application/json")
+    @POST
+    @Path("/users")
+    @Consumes("application/json")
     Observable<User> saveUser(User user);
 
-    @RequestMapping(value = "/users", method = RequestMethod.POST, consumes = "application/json")
-    Observable<User> saveUser(User user, @RequestHeader("Auth-Token") String token);
+    @POST
+    @Path("/users")
+    @Consumes("application/json")
+    Observable<User> saveUser(User user, @HeaderParam("Auth-Token") String token);
 
-    @RequestMapping(value = "/users", method = RequestMethod.POST, consumes = "application/json")
+    @POST
+    @Path("/users")
+    @Consumes("application/json")
     Observable<User> saveUserWithExplicitBody(String userJson);
 
-    @RequestMapping(value = "/users", method = RequestMethod.POST, consumes = "application/json")
-    Observable<User> saveUserWithExplicitBody(String userJson, @RequestHeader("Auth-Token") String token);
+    @POST
+    @Path("/users")
+    @Consumes("application/json")
+    Observable<User> saveUserWithExplicitBody(String userJson, @HeaderParam("Auth-Token") String token);
 }


### PR DESCRIPTION
With this change, HTTP Client uses JAX-RS 1.1 annotations so it's a little bit more standard (I guess) than using Spring or Feign annotations.

Not sure if it's worth it, though. What do you guys think? @kmruiz @ramonibz @aramirez-es @victuxbb @ruben-perez @padilo

Please, note that it's not JAX-RS 2.0 since there are no support in Feign.